### PR TITLE
WIP: added novisim as metadata flag for h5 files

### DIFF
--- a/src/lib/py/esrf_read.py
+++ b/src/lib/py/esrf_read.py
@@ -36,7 +36,8 @@ def esrf_edf_metadata(filename):
             if (len(kv) >= 2):
                 meta[kv[0].strip()] = kv[1].strip()
 
-        assert meta["ByteOrder"] == "LowByteFirst"
+        # removing " ;"
+        assert meta["ByteOrder"].split()[0] == "LowByteFirst"
 
         if (meta["DataType"] == "UnsignedShort"):
             meta["NumpyType"] = np.uint16

--- a/src/processing_steps/0200_generate_byte_hdf5.py
+++ b/src/processing_steps/0200_generate_byte_hdf5.py
@@ -71,7 +71,7 @@ if __name__ == "__main__":
 
     # Store metadata in both files for each subvolume scan
     for h5file in [h5file_msb,h5file_lsb]:
-        # never a novisim tomogram at this point, but added to all *.h5 files for later checks
+        # h5 file is marked as not being related to novisim. This is used in later checks.
         h5file.attrs["novisim"] = 0
         grp_meta = h5file.create_group("metadata")
         for i in range(len(subvolume_metadata)):

--- a/src/processing_steps/0200_generate_byte_hdf5.py
+++ b/src/processing_steps/0200_generate_byte_hdf5.py
@@ -71,6 +71,8 @@ if __name__ == "__main__":
 
     # Store metadata in both files for each subvolume scan
     for h5file in [h5file_msb,h5file_lsb]:
+        # never a novisim tomogram at this point, but added to all *.h5 files for later checks
+        h5file.attrs["novisim"] = 0
         grp_meta = h5file.create_group("metadata")
         for i in range(len(subvolume_metadata)):
             subvolume_info = subvolume_metadata[i]

--- a/src/processing_steps/0225_generate_hdf5_novisim.py
+++ b/src/processing_steps/0225_generate_hdf5_novisim.py
@@ -112,6 +112,7 @@ if __name__ == "__main__":
     h5_msb = h5py.File(f'{output_dir}/msb/{args.sample}.h5', 'w')
 
     for h5, tomo in [(h5_lsb, tomo_lsb), (h5_msb, tomo_msb)]:
+        h5.attrs["novisim"] = 1 # set flag to mark file as novisim tomogram
         h5.create_dataset('subvolume_dimensions', (1,3), data=[[nz, ny, nx]], dtype=np.uint16)
         h5.create_dataset('subvolume_range', (1,2,), dtype=np.float32, data=np.array([0, 65535]))
         h5_tomo = h5.create_dataset('voxels', (nz, ny, nx), dtype=np.uint8, data=tomo)

--- a/src/processing_steps/0600_segment_implant_cc.py
+++ b/src/processing_steps/0600_segment_implant_cc.py
@@ -42,7 +42,9 @@ if __name__ == "__main__":
     global_vmax = np.max(h5meta['subvolume_range'][:,1])
     values      = np.linspace(global_vmin,global_vmax,2**16)
     implant_threshold_u16 = np.argmin(np.abs(values-implant_threshold))
-    if 'novisim' in args.sample:
+
+    # check if chosen sample has novisim flag set in metadata
+    if h5meta["novisim"]:
         implant_threshold_u16 = implant_threshold_u16_novisim
 
     if args.verbose >= 2: print(f"""

--- a/src/processing_steps/0750_bone_region.py
+++ b/src/processing_steps/0750_bone_region.py
@@ -33,6 +33,7 @@ if __name__ == "__main__":
     implant_file = h5py.File(f"{hdf5_root}/masks/{args.sample_scale}x/{args.sample}.h5",'r')
     implant      = implant_file["implant/mask"][:].astype(np.uint8)
     voxel_size   = implant_file["implant"].attrs["voxel_size"]
+    novisimflag = implant_file.attrs["novisim"]
     implant_file.close()
 
     nz, ny, nx = implant.shape
@@ -132,7 +133,7 @@ if __name__ == "__main__":
     del front_part
     if args.plotting: plot_middle_planes(bone_mask1, plotting_dir, 'implant-bone1-sanity', verbose=args.verbose)
 
-    if 'novisim' in args.sample:
+    if novisimflag:
         closing_diameter, opening_diameter, implant_dilate_diameter = 400, 300, 15 # micrometers
     else:
         closing_diameter, opening_diameter, implant_dilate_diameter = 400, 300, 5 # micrometers

--- a/src/processing_steps/1000_compute_histograms.py
+++ b/src/processing_steps/1000_compute_histograms.py
@@ -532,7 +532,8 @@ if __name__ == '__main__':
         if args.verbose >= 1: print(f"Loaded {gb:.02f} GB in {end-start} ({gb / (end-start).total_seconds()} GB/s)")
         verify_and_benchmark(voxels, field, plotting_dir, args.voxel_bins // args.sample_scale, args.benchmark_runs, args.verbose)
     else:
-        if 'novisim' in args.sample:
+        h5meta = h5py.File(f'{hdf5_root}/hdf5-byte/msb/{args.sample}.h5', 'r')
+        if h5meta["novisim"]:
             implant_threshold = 40000
         else:
             implant_threshold = implant_threshold_u16


### PR DESCRIPTION
This addition requires a test before merge!!!
Currently `processing_steps/0100_cache_esrf2013.py` and `processing_steps/0200_generate_byte_hdf5.py` can only be run using a special file located on James' ERDA directory.

This branch contains two simple additions, that need to be tested/verified:
 1. All h5 files have gotten an attribute at file-level called `novisim`. For h5 files that are not related to novisim, the attribute will have value `0`, or otherwise `1`. This avoids various checks in subsequent processing steps being hardcoded.
 2. In `lib/py/esrf_read.py` in the function `esrf_edf_metadata()`, there also seems to be an error in the string received for meta["ByteOrder"] which contains a whitespace and a semicolon. For now the quick fix was to strip the string and keep only the first part.